### PR TITLE
Fix typechecking with latest sail release

### DIFF
--- a/src/instrs.sail
+++ b/src/instrs.sail
@@ -40426,7 +40426,7 @@ function clause __DecodeA64 (pc, ([bitzero, bitone, bitzero, bitone, bitone, bit
 }
 
 val execute_aarch64_instrs_vector_transfer_vector_cpy_dup_sisd : forall 'd 'datasize 'elements 'esize 'idxdsize 'index 'n,
-  (0 <= 'n & 'n <= 31 & 'idxdsize in {64, 128} & 'esize in {8, 16, 32, 64, 128, 256} & 0 <= 'd & 'd <= 31).
+  (0 <= 'n & 'n <= 31 & 'idxdsize in {64, 128} & 'esize in {8, 16, 32, 64, 128, 256} & 0 <= 'd & 'd <= 31 & 'datasize >= 0).
   (int('d), int('datasize), int('elements), int('esize), int('idxdsize), int('index), int('n)) -> unit effect {escape, rreg, undef, wreg}
 
 function execute_aarch64_instrs_vector_transfer_vector_cpy_dup_sisd (d, datasize, elements, esize, idxdsize, index, n) = {

--- a/src/v8_base.sail
+++ b/src/v8_base.sail
@@ -38103,7 +38103,7 @@ function HaveCRCExt () = {
     return(HasArchVersion(ARMv8p1) | __IMPDEF_boolean("Have CRC extension"))
 }
 
-val BitReverse : forall ('N : Int). bits('N) -> bits('N) effect {undef}
+val BitReverse : forall ('N : Int), 'N >= 0. bits('N) -> bits('N) effect {undef}
 
 function BitReverse data = {
     result : bits('N) = undefined;


### PR DESCRIPTION
The newest version of sail complains with:
```
v8_base.sail:38109.24-33:
38109 |    result : bits('N) = undefined;
      |                        ^-------^
      | Type bits('N) is empty
make: *** [Makefile:87: check_sail] Error 1
```
As suggested by @Alasdair, add >= 0 constraints to fix this error.
Fixes: https://github.com/CTSRD-CHERI/sail-morello/issues/2