### PR TITLE
Update PCC and PC, plus instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ from the Sail specification (although for the C emulator, they contain only the
 source, no binaries;  use the `gen_c` Makefile target to build a binary).
 
 To freshly build the artifacts, make sure that a recent version of [Sail][sail]
-is installed (last tested using revision `87118b39`), and use the Makefile
+is installed (last tested using `opam` version `sail.0.17.1`), and use the Makefile
 target `gen_c` to generate an emulator, and `gen_isa` to generate a model for
 the Isabelle theorem prover.
+
+Building `morello.ir` depends additionally on `isla-sail`: 
+check out a development version of `isla` (version tested `1ac01cd`), 
+`cd` into `isla/isla-sail`, run `make` and then from the current path run 
+`PATH=[path to isla-sail]:$PATH make gen_ir`.
 
 The `boot.sh` script downloads, builds, and runs a (non-capability AArch64)
 version of Linux above the C emulator.

--- a/src/elfmain.sail
+++ b/src/elfmain.sail
@@ -99,7 +99,7 @@ val isla_footprint_no_init : bits(32) -> bool effect {configuration, escape, rme
 function isla_footprint_no_init(opcode) = {
   SEE = -1;
 
-  __PC_changed = false;
+  __BranchTaken = false;
   __ThisInstr = opcode;
   DBGEN = LOW;
 
@@ -112,6 +112,7 @@ function isla_footprint_no_init(opcode) = {
   check_cycle_count();
   try {
     __DecodeA64(UInt(_PC), opcode);
+    Step_PC();
     true
   } catch {
     _ => false

--- a/src/elfmain.sail
+++ b/src/elfmain.sail
@@ -101,7 +101,6 @@ function isla_footprint_no_init(opcode) = {
 
   __PC_changed = false;
   __ThisInstr = opcode;
-  __currentInstrLength = 4;
   DBGEN = LOW;
 
   isla_reset_registers();
@@ -113,7 +112,6 @@ function isla_footprint_no_init(opcode) = {
   check_cycle_count();
   try {
     __DecodeA64(UInt(_PC), opcode);
-    if (__PC_changed == false) then _PC = _PC + __currentInstrLength else ();
     true
   } catch {
     _ => false


### PR DESCRIPTION
- Invoked Step_PC inside isla_footprint_no_init to increment the PCC (and update PC) when the instruction wasn't a branching one
- Added instructions to README for generating `morello.ir` using `make gen_ir`